### PR TITLE
move await call inside asynchronous function for <= safari 14

### DIFF
--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -74,9 +74,8 @@ const miloLibs = setLibs(LIBS);
   });
 }());
 
-const { loadArea, loadDelayed, setConfig, loadLana } = await import(`${miloLibs}/utils/utils.js`);
-
 (async function loadPage() {
+  const { loadArea, loadDelayed, setConfig, loadLana } = await import(`${miloLibs}/utils/utils.js`);
   setConfig({ ...CONFIG, miloLibs });
   await loadArea();
   loadDelayed();


### PR DESCRIPTION
see https://github.com/adobecom/milo-college/pull/5

Before: https://main--acrobat--adobecom.hlx.page/acrobat/
After: https://mwpw-121309--acrobat--adobecom.hlx.page/acrobat/