### PR TITLE
Mwpw 120007 Legacy Browser redirect

### DIFF
--- a/acrobat/scripts/legacyBrowser.js
+++ b/acrobat/scripts/legacyBrowser.js
@@ -1,6 +1,6 @@
 const EOLBrowserPage = 'https://acrobat.adobe.com/home/index-browser-eol.html';
 
-// Check if browser version is compatible with DC Converter Widget
+// Check if browser version is compatible with minimal milo / DC widget requirements
 export function browserDetection() {
   // Uses Bowser Library (https://lancedikson.github.io/bowser/docs/Parser.html)
   const parser = bowser.getParser(window.navigator.userAgent);
@@ -9,19 +9,24 @@ export function browserDetection() {
 
   if (!browserName) return null;
   let majorVersion = null;
+  let minorVersion = null;
 
   if (version) {
     const versionElements = version.split('.');
     if (versionElements.length >= 1) {
       majorVersion = parseInt(versionElements[0], 10);
+      minorVersion = parseInt(versionElements[1], 10);
     }
   }
 
+  console.log(`Version: ${majorVersion}.${minorVersion}`)
+  // IE is not supported
   if (/Internet Explorer/i.test(browserName)) return 'IE';
 
   if (/Microsoft Edge/i.test(browserName)) {
     // if we cannot determine major version, we should not redirect to be on the safe side
-    if (!majorVersion || majorVersion >= 79) {
+    // EDGE: DC Widget >= 79, Milo >= 85
+    if (!majorVersion || majorVersion >= 85) {
       return 'EDGE-CHROMIUM';
     }
     return 'EDGE-LEGACY';
@@ -33,7 +38,8 @@ export function browserDetection() {
 
   if (/Safari/i.test(browserName)) {
     // if we cannot determine major version, we should not redirect to be on the safe side
-    return (!majorVersion || majorVersion >= 13) ? 'SAFARI' : 'SAFARI-LEGACY';
+    // Safari: DC Widget > 12, Milo >= 13.1
+    return (!majorVersion || (majorVersion >= 13 && minorVersion >= 1)) ? 'SAFARI' : 'SAFARI-LEGACY';
   }
   return null;
 }

--- a/acrobat/scripts/legacyBrowser.js
+++ b/acrobat/scripts/legacyBrowser.js
@@ -17,8 +17,6 @@ export function browserDetection() {
     }
   }
 
-  console.log(`Version: ${version}`);
-
   // IE is not supported
   if (/Internet Explorer/i.test(browserName)) return 'IE';
 

--- a/acrobat/scripts/legacyBrowser.js
+++ b/acrobat/scripts/legacyBrowser.js
@@ -9,24 +9,23 @@ export function browserDetection() {
 
   if (!browserName) return null;
   let majorVersion = null;
-  let minorVersion = null;
 
   if (version) {
     const versionElements = version.split('.');
     if (versionElements.length >= 1) {
       majorVersion = parseInt(versionElements[0], 10);
-      minorVersion = parseInt(versionElements[1], 10);
     }
   }
 
-  console.log(`Version: ${majorVersion}.${minorVersion}`)
+  console.log(`Version: ${version}`);
+
   // IE is not supported
   if (/Internet Explorer/i.test(browserName)) return 'IE';
 
   if (/Microsoft Edge/i.test(browserName)) {
     // if we cannot determine major version, we should not redirect to be on the safe side
-    // EDGE: DC Widget >= 79, Milo >= 85
-    if (!majorVersion || majorVersion >= 85) {
+    // EDGE: DC Widget >= 79, Milo >= 86
+    if (!majorVersion || majorVersion >= 86) {
       return 'EDGE-CHROMIUM';
     }
     return 'EDGE-LEGACY';
@@ -38,8 +37,8 @@ export function browserDetection() {
 
   if (/Safari/i.test(browserName)) {
     // if we cannot determine major version, we should not redirect to be on the safe side
-    // Safari: DC Widget > 12, Milo >= 13.1
-    return (!majorVersion || (majorVersion >= 13 && minorVersion >= 1)) ? 'SAFARI' : 'SAFARI-LEGACY';
+    // Safari: DC Widget > 12, Milo >= 14 
+    return (!majorVersion || majorVersion >= 14 ) ? 'SAFARI' : 'SAFARI-LEGACY';
   }
   return null;
 }

--- a/acrobat/scripts/scripts.js
+++ b/acrobat/scripts/scripts.js
@@ -27,7 +27,7 @@ head.appendChild(clsPopIn);
 
 // if there is a DC widget on the page check for legacy browser and redirect
 // to EOL Browser page if needed.
-if (document.querySelector('.widget')) {
+if (document.querySelector('.dc-converter-widget')) {
   redirectLegacyBrowsers();
 }
 


### PR DESCRIPTION
Checks if Browser is:
- Safari >= 14
- Edge >= 86

otherwise redirect to https://acrobat.adobe.com/home/index-browser-eol.html

Before : https://main--acrobat--adobecom.hlx.page/acrobat/online/pdf-to-ppt
After : https://mwpw-120007--acrobat--adobecom.hlx.page/acrobat/online/pdf-to-ppt

Note for testing:
- Testing lower then Safari 13.1 (labeled as 13 in SauceLabs) or Edge  80 will not work, as milo itself will fail to load.